### PR TITLE
Apply fix to uvm build

### DIFF
--- a/script/nvidia/nvidia-340.108/checksums
+++ b/script/nvidia/nvidia-340.108/checksums
@@ -5,4 +5,4 @@
 f635bcb730da52a14ec099f804b9c039  download/nvidia-340.108-fix-5.8-kernel-compile.patch
 0507bfe7ac518f059861a241a3c99995  download/nvidia-340.108-fix-5.9-kernel-compile.patch
 c7cba9c5c0c4274fa0cc5094f0be0b5c  download/nvidia-340.108-fix-5.10-kernel-compile.patch
-bcfc4f46408feff6de8ba416d26acdd0  download/nvidia-340.108-fix-5.11-kernel-compile.patch
+d0ba67b63df4aefb5aa3d1f222d513fd  download/nvidia-340.108-fix-5.11-kernel-compile.patch

--- a/script/nvidia/nvidia-340.108/files/nvidia-340.108-fix-5.11-kernel-compile.patch
+++ b/script/nvidia/nvidia-340.108/files/nvidia-340.108-fix-5.11-kernel-compile.patch
@@ -10,3 +10,15 @@ diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-linux.h NVIDIA-Linux-x86_64
  
  #include <linux/pci.h>              /* pci_find_class, etc              */
  #include <linux/interrupt.h>        /* tasklets, interrupt helpers      */
+--- a/kernel/uvm/nvidia_uvm_linux.h	2019-12-11 17:04:24.000000000 -0500
++++ b/kernel/uvm/nvidia_uvm_linux.h	2021-02-24 06:26:26.237367942 -0500
+@@ -141,7 +141,7 @@
+ #if !defined(NV_VMWARE)
+ #include <asm/tlbflush.h>           /* flush_tlb(), flush_tlb_all()     */
+ #endif
+-#include <asm/kmap_types.h>         /* page table entry lookup          */
++//#include <asm/kmap_types.h>         /* page table entry lookup          */
+ 
+ #include <linux/interrupt.h>        /* tasklets, interrupt helpers      */
+ #include <linux/timer.h>
+


### PR DESCRIPTION
Cannot build nvidia_uvm.ko without extending the strategy of commenting
out the #include to it as well.