### PR TITLE
kernel: enable mmc1,uart1 for WiFi and BT, and eMMC mmc2 on H616 Tanix-TX6s

### DIFF
--- a/script/kernel/linux-5.12/files/0595-arm64-dts-allwnner-h616-add-Tanix-TX6s-TVbox.patch
+++ b/script/kernel/linux-5.12/files/0595-arm64-dts-allwnner-h616-add-Tanix-TX6s-TVbox.patch
@@ -9,7 +9,7 @@ diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/Makefile linux-5.12.5-
 diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s.dts linux-5.12.5-new/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s.dts
 --- linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s.dts	1970-01-01 01:00:00.000000000 +0100
 +++ linux-5.12.5-new/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s.dts	2021-05-25 18:17:32.416665828 +0200
-@@ -0,0 +1,297 @@
+@@ -0,0 +1,329 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +/*
 + * Copyright (C) 2020 Arm Ltd.
@@ -56,12 +56,6 @@ diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s
 +			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>; /* PC12 */
 +			default-state = "on";
 +		};
-+
-+		led-1 {
-+			function = LED_FUNCTION_STATUS;
-+			color = <LED_COLOR_ID_GREEN>;
-+			gpios = <&pio 2 13 GPIO_ACTIVE_HIGH>; /* PC13 */
-+		};
 +	};
 +
 +	reg_vcc5v: vcc5v {
@@ -80,8 +74,15 @@ diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s
 +		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&reg_vcc5v>;
 +		enable-active-high;
-+		gpio = <&pio 2 16 GPIO_ACTIVE_HIGH>; /* PC16 */
++		/* gpio = <&pio 2 16 GPIO_ACTIVE_HIGH>; PC16 */
 +		status = "okay";
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 2 GPIO_ACTIVE_LOW>; /* PL2 */
++		clocks = <&rtc 1>;
++		clock-names = "ext_clock";
 +	};
 +};
 +
@@ -148,6 +149,31 @@ diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s
 +	//cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;	/* PF6 */
 +	broken-cd;
 +	bus-width = <4>;
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_dcdce>;
++	vqmmc-supply = <&reg_dcdce>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&r_pio>;
++		interrupts = <0 3 IRQ_TYPE_LEVEL_LOW>; /* PL3 */
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc2 {
++	vmmc-supply = <&reg_dcdce>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
 +	status = "okay";
 +};
 +
@@ -275,22 +301,28 @@ diff -Naur linux-5.12.5-old/arch/arm64/boot/dts/allwinner/sun50i-h616-tanix-tx6s
 +	};
 +};
 +
-+&spi0  {
-+	status = "okay";
-+
-+	flash@0 {
-+		#address-cells = <1>;
-+		#size-cells = <1>;
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <40000000>;
-+	};
-+};
-+
 +&uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_ph_pins>;
 +	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		clocks = <&rtc 1>;
++		clock-names = "lpo";
++		vbat-supply = <&reg_dcdce>;
++		vddio-supply = <&reg_dcdce>;
++		device-wakeup-gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
++		host-wakeup-gpios = <&r_pio 0 5 GPIO_ACTIVE_HIGH>; /* PL5 */
++		shutdown-gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
++	};
 +};
 +
 +&usbotg {


### PR DESCRIPTION
Remove configuration for led-1 and spi0 which are not used on the TX6s
and conflict with GPIOs. Also Comment PC16 out, which is used by mmc2.

The wifi and bluetooth are not yet active (should be considered draft.)
 
But mmc2 is active:

```
root@tx6s:~ # dmesg | grep mmc
[    5.277314] vcc-eth-mmc: supplied by vcc-5v
[    5.383068] sunxi-mmc 4020000.mmc: initialized, max. request size: 16384 KB, uses new timings mode
[    5.409362] sunxi-mmc 4022000.mmc: initialized, max. request size: 2048 KB, uses new timings mode
[    5.474933] mmc1: host does not support reading read-only switch, assuming write-enable
[    5.490234] mmc1: new high speed SDHC card at address aaaa
[    5.501443] mmcblk1: mmc1:aaaa SC32G 29.7 GiB
[    5.517720]  mmcblk1: p1 p2
[    5.627579] mmc2: new DDR MMC card at address 0001
[    5.634307] mmcblk2: mmc2:0001 SCA64G 57.7 GiB
[    5.639787] mmcblk2boot0: mmc2:0001 SCA64G partition 1 4.00 MiB
[    5.646603] mmcblk2boot1: mmc2:0001 SCA64G partition 2 4.00 MiB
[    5.657183]  mmcblk2: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17
[    6.614565] EXT4-fs (mmcblk1p2): recovery complete
[    6.622398] EXT4-fs (mmcblk1p2): mounted filesystem with ordered data mode. Opts: (null). Quota mode: disabled.
[   25.980561] FAT-fs (mmcblk1p1): Volume was not properly unmounted. Some data may be corrupt. Please run fsck.
```
```
[    8.805001] Bluetooth: Core ver 2.22
[    8.830302] Bluetooth: HCI device and connection manager initialized
[    8.837052] Bluetooth: HCI socket layer initialized
[    8.842544] Bluetooth: L2CAP socket layer initialized
[    8.848457] Bluetooth: SCO socket layer initialized
[    8.922847] Bluetooth: HCI UART driver ver 2.3
[    8.927542] Bluetooth: HCI UART protocol H4 registered
[    8.932799] Bluetooth: HCI UART protocol BCSP registered
[    8.938524] Bluetooth: HCI UART protocol LL registered
[    8.945733] Bluetooth: HCI UART protocol ATH3K registered
[    8.958923] Bluetooth: HCI UART protocol Three-wire (H5) registered
[    8.967250] Bluetooth: HCI UART protocol Intel registered
[    8.981509] Bluetooth: HCI UART protocol Broadcom registered
[    8.987573] Bluetooth: HCI UART protocol QCA registered
[    9.000106] Bluetooth: HCI UART protocol Marvell registered
```