### PR TITLE
u-boot: add eMMC mmc2 to Tanix-TX6s H616

### DIFF
--- a/script/bootloaders/u-boot-h616/checksums
+++ b/script/bootloaders/u-boot-h616/checksums
@@ -1,5 +1,5 @@
 bcbc92e393f557f9744f994db96558f6  download/647b392bf20614006917d5fcd3390347a668eee5.zip
 7f05d8ab3ad5a0745709c43bdd227660  download/add-emac2-to-h6-h616.patch
-c1065894a678cd5986162ea582bad492  download/add-h616-tanix-tx6s-defconfig.patch
+4abc675ff58caaf90a0428a5dae88dcc  download/add-h616-tanix-tx6s-defconfig.patch
 e0d7d5a15b5c263ecc51cd83412a0965  download/add-h616-x96-mate-defconfig.patch
 426f026c19435ab8d450cf89380b9ef7  download/add-h616-t95-defconfig.patch

--- a/script/bootloaders/u-boot-h616/files/add-h616-tanix-tx6s-defconfig.patch
+++ b/script/bootloaders/u-boot-h616/files/add-h616-tanix-tx6s-defconfig.patch
@@ -14,7 +14,7 @@ diff -Naur u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-old/arch/arm/dt
 diff -Naur u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-old/arch/arm/dts/sun50i-h616-tanix-tx6s.dts u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-new/arch/arm/dts/sun50i-h616-tanix-tx6s.dts
 --- u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-old/arch/arm/dts/sun50i-h616-tanix-tx6s.dts	1970-01-01 01:00:00.000000000 +0100
 +++ u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-new/arch/arm/dts/sun50i-h616-tanix-tx6s.dts	2021-05-11 20:52:30.906666606 +0200
-@@ -0,0 +1,224 @@
+@@ -0,0 +1,232 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +/*
 + * Copyright (C) 2021 Arm Ltd.
@@ -101,6 +101,14 @@ diff -Naur u-boot-sunxi-647b392bf20614006917d5fcd3390347a668eee5-old/arch/arm/dt
 +	//cd-gpios = <&pio 8 16 GPIO_ACTIVE_LOW>;	/* PI16 */
 +	broken-cd;
 +	bus-width = <4>;
++	status = "okay";
++};
++
++&mmc2 {
++	vmmc-supply = <&reg_dcdce>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
Adding the &mmc2 node allows u-boot to see the node.

=> mmc list
mmc@4020000: 0 (SD)
mmc@4022000: 1

Not Complete, as the following error occurs when switching the the eMMC
```
=> mmc dev 1
Card did not respond to voltage select! : -110
```

The 2021.04 and 2021.07-rc3 boot boot fine (but only from the SD card.)
Doing a direct u-boot from the eMMC fails too.

```
U-Boot SPL 2021.07-rc3 (Jun 06 2021 - 05:14:03 +0000)
DRAM: 4096 MiB
Trying to boot from MMC2
MMC Device 1 not found
spl: could not find mmc device 1. error: -19
SPL: failed to boot from all boot devices
### ERROR ### Please RESET the board ###
```