### PR TITLE
check.mk: typo

### DIFF
--- a/script/meta/minimyth/files/check.mk
+++ b/script/meta/minimyth/files/check.mk
@@ -12,7 +12,7 @@ mm-all:
 	@which bash > /dev/null 2>&1 ; \
 		if [ ! "$$?" = "0" ] ; then \
 			echo " " ; \
-			echo "erorr: your system does not contain the program 'which' and/or 'bash'" ; \
+			echo "error: your system does not contain the program 'which' and/or 'bash'" ; \
 			echo " " ; \
 			exit 1 ; \
 		fi


### PR DESCRIPTION
Small typo:

also on my bionic container - I have had to create the following symlink to successfully compile.

`cd /usr/include; ln -s x86_64-linux-gnu/asm .`

references:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92247#c10
- https://blog.csdn.net/yihui8/article/details/8620914