### PR TITLE
patch nv-vm.c

### DIFF
--- a/script/nvidia/nvidia-340.108/files/0011-fix-compile-on-5.18.patch
+++ b/script/nvidia/nvidia-340.108/files/0011-fix-compile-on-5.18.patch
@@ -125,3 +125,21 @@ diff --speed-large-files --no-dereference --minimal -Naur NVIDIA-Linux-x86_64-34
      nv_gem_prime_vunmap(gem, map->vaddr);
      map->vaddr = NULL;
  }
+diff --speed-large-files --no-dereference --minimal -Naur NVIDIA-Linux-x86_64-340.108/kernel/nv-vm.c NVIDIA-Linux-x86_64-340.108/kernel/nv-vm.c 
+--- NVIDIA-Linux-x86_64-340.108/kernel/nv-vm.c	2019-12-12 01:04:24.000000000 +0300
++++ NVIDIA-Linux-x86_64-340.108/kernel/nv-vm.c	2022-06-03 22:39:15.915870000 +0300
+@@ -169,12 +169,12 @@
+ 
+ static inline int nv_map_sg(struct pci_dev *dev, struct scatterlist *sg)
+ {
+-    return pci_map_sg(dev, sg, 1, PCI_DMA_BIDIRECTIONAL);
++	return dma_map_sg(&dev->dev, sg, 1, DMA_BIDIRECTIONAL);
+ }
+ 
+ static inline void nv_unmap_sg(struct pci_dev *dev, struct scatterlist *sg)
+ {
+-    pci_unmap_sg(dev, sg, 1, PCI_DMA_BIDIRECTIONAL);
++    dma_unmap_sg(&dev->dev, sg, 1, DMA_BIDIRECTIONAL);
+ }
+ 
+ #define NV_MAP_SG_MAX_RETRIES 16


### PR DESCRIPTION
pci_map_sg and pci_unmap_sg removed from 5.18 kernel see: https://lore.kernel.org/lkml/CAK8P3a2G8Lze=0CkdL8o7OH5M-oyKPmee9x3YcdFAa4KJvDtxA@mail.gmail.com/T/